### PR TITLE
feat: add additional_allowed_role_arns for cross-account access

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,7 +1,10 @@
 locals {
   enabled = module.this.enabled
 
-  additional_allowed_roles = compact([for prometheus in module.prometheus : prometheus.outputs.access_role_arn])
+  additional_allowed_roles = compact(concat(
+    [for prometheus in module.prometheus : prometheus.outputs.access_role_arn],
+    var.additional_allowed_role_arns
+  ))
 }
 
 module "security_group" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -30,6 +30,12 @@ variable "prometheus_source_accounts" {
 }
 
 
+variable "additional_allowed_role_arns" {
+  type        = list(string)
+  description = "A list of IAM role ARNs that the Grafana workspace role should be allowed to assume. Use this for cross-account access to services like CloudWatch"
+  default     = []
+}
+
 variable "private_network_access_enabled" {
   type        = bool
   description = "If set to `true`, enable the VPC Configuration to allow this workspace to access the private network using outputs from the vpc component"


### PR DESCRIPTION
## What
Add `additional_allowed_role_arns` variable that accepts a list of IAM role ARNs the Grafana workspace role should be allowed to assume. These are concatenated with the existing Prometheus access role ARNs in `additional_allowed_roles`.

This enables cross-account access to services like CloudWatch without requiring remote-state lookups in the component. Role ARNs can be resolved via Atmos `!terraform.state` functions in the stack catalog and passed directly as a variable.

## Why
The component currently only supports cross-account access for Prometheus (via `prometheus_source_accounts` and remote-state). For CloudWatch cross-account access, there was no way to grant the Grafana workspace role permission to assume CloudWatch access roles in other accounts.

Rather than adding another service-specific remote-state lookup pattern, this adds a generic variable that works with any IAM role and keeps cross-component wiring in the stack configuration layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying additional cross-account IAM role ARNs, enabling Grafana workspace access to services like CloudWatch across AWS accounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->