### PR TITLE
feat: expose workspace_configuration and grafana_version

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -29,7 +29,7 @@ module "managed_grafana" {
   prometheus_policy_enabled = var.prometheus_policy_enabled
   additional_allowed_roles  = local.additional_allowed_roles
 
-  configuration   = var.workspace_configuration
+  configuration   = var.workspace_configuration != null ? jsonencode(var.workspace_configuration) : null
   grafana_version = var.grafana_version
 
   vpc_configuration = var.private_network_access_enabled ? {

--- a/src/main.tf
+++ b/src/main.tf
@@ -22,12 +22,15 @@ module "security_group" {
 
 module "managed_grafana" {
   source  = "cloudposse/managed-grafana/aws"
-  version = "0.5.0"
+  version = "0.6.0"
 
   enabled = local.enabled
 
   prometheus_policy_enabled = var.prometheus_policy_enabled
   additional_allowed_roles  = local.additional_allowed_roles
+
+  configuration   = var.workspace_configuration
+  grafana_version = var.grafana_version
 
   vpc_configuration = var.private_network_access_enabled ? {
     subnet_ids         = module.vpc.outputs.private_subnet_ids

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -43,20 +43,23 @@ variable "private_network_access_enabled" {
 }
 
 variable "workspace_configuration" {
-  type        = string
+  type        = any
   description = <<-EOT
-    JSON string passed through to `aws_grafana_workspace.configuration`.
-    Most commonly used to flip the workspace from legacy alerting to
-    Grafana unified alerting permanently:
+    Workspace-level settings passed through to `aws_grafana_workspace.configuration`.
+    Authored as a native object/map; the component jsonencodes it before applying,
+    so callers can express the config in YAML rather than embedding pre-encoded JSON
+    strings:
 
-      workspace_configuration = jsonencode({
-        unifiedAlerting = { enabled = true }
-        plugins         = { pluginAdminEnabled = false }
-      })
+      workspace_configuration:
+        unifiedAlerting:
+          enabled: true
+        plugins:
+          pluginAdminEnabled: false
 
-    Without this, AMG runs in legacy alerting mode and any unified-alerting
-    resources provisioned via the Grafana API exist but are never evaluated
-    by the running engine. See:
+    Most commonly used to flip the workspace from legacy alerting to Grafana unified
+    alerting permanently. Without this, AMG runs in legacy alerting mode and any
+    unified-alerting resources provisioned via the Grafana API exist but are never
+    evaluated by the running engine. See:
     https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html
   EOT
   default     = null

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -41,3 +41,33 @@ variable "private_network_access_enabled" {
   description = "If set to `true`, enable the VPC Configuration to allow this workspace to access the private network using outputs from the vpc component"
   default     = false
 }
+
+variable "workspace_configuration" {
+  type        = string
+  description = <<-EOT
+    JSON string passed through to `aws_grafana_workspace.configuration`.
+    Most commonly used to flip the workspace from legacy alerting to
+    Grafana unified alerting permanently:
+
+      workspace_configuration = jsonencode({
+        unifiedAlerting = { enabled = true }
+        plugins         = { pluginAdminEnabled = false }
+      })
+
+    Without this, AMG runs in legacy alerting mode and any unified-alerting
+    resources provisioned via the Grafana API exist but are never evaluated
+    by the running engine. See:
+    https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html
+  EOT
+  default     = null
+}
+
+variable "grafana_version" {
+  type        = string
+  description = <<-EOT
+    Pin the Grafana major version supported by the workspace. Supported AMG
+    values include `9.4`, `10.4`, `12.4`. Leave null to follow AMG's
+    latest-supported default.
+  EOT
+  default     = null
+}


### PR DESCRIPTION
## what

- Bumps `cloudposse/managed-grafana/aws` from `v0.5.0` to `v0.6.0` to pick up the `configuration` and `grafana_version` arguments on `aws_grafana_workspace`
- Adds two component-level variables, both `null` by default:
  - `workspace_configuration` (`type = any`) — native object plumbed through to `aws_grafana_workspace.configuration` after `jsonencode()`. Lets callers express the config in YAML rather than embedding pre-encoded JSON strings.
  - `grafana_version` — pin a specific Grafana major (9.4 / 10.4 / 12.4)

## why

The `aws_grafana_workspace` resource exposes a `configuration` JSON attribute used to enable Grafana unified alerting permanently. Without `unifiedAlerting.enabled = true`, AMG workspaces created in regions with the legacy-alerting default (or workspaces that pre-date AMG's unified-alerting rollout) run in legacy alerting mode. Any unified-alerting resources provisioned via the Grafana API exist but are **never evaluated** by the running engine. The Grafana UI surfaces this as a "preview of upgraded alerting / no rules being evaluated" banner.

`grafana_version` is useful for callers who want predictable upgrades rather than tracking AMG's latest-supported default automatically.

Both arguments were exposed on the underlying module via [cloudposse/terraform-aws-managed-grafana#12](https://github.com/cloudposse/terraform-aws-managed-grafana/pull/12) (merged, released as `v0.6.0`). This PR threads them through the component wrapper.

### Why `type = any` for `workspace_configuration` instead of `string`?

The underlying `aws_grafana_workspace.configuration` is a string of JSON. We could pass it through as a string verbatim, but that forces stack-config authors to embed pre-encoded JSON in YAML — awkward to write, awkward to read, easy to break with quoting:

```yaml
# string-typed (awkward)
workspace_configuration: |
  {
    "unifiedAlerting": { "enabled": true },
    "plugins": { "pluginAdminEnabled": false }
  }
```

Switching to `type = any` lets the value be authored as a native Atmos/YAML object and `jsonencode`'d inside the module:

```yaml
# any-typed (clean)
workspace_configuration:
  unifiedAlerting:
    enabled: true
  plugins:
    pluginAdminEnabled: false
```

The resulting JSON is byte-identical. AMG's `configuration` schema continues to evolve (AWS adds new keys periodically), so `any` also avoids forcing this module to bump every time AWS adds a field.

## example usage

```yaml
components:
  terraform:
    grafana:
      metadata:
        component: managed-grafana/workspace
      vars:
        workspace_configuration:
          unifiedAlerting:
            enabled: true
          plugins:
            pluginAdminEnabled: false
        grafana_version: "10.4"
```

## references

- [`aws_grafana_workspace` configuration options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#workspace-configuration-options)
- [AMG: Working in your Grafana workspace](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html)
- Underlying module PR: [cloudposse/terraform-aws-managed-grafana#12](https://github.com/cloudposse/terraform-aws-managed-grafana/pull/12)
- Sister PR adding `manage_alerts` to the AMP datasource component: [aws-managed-grafana-data-source-managed-prometheus#60](https://github.com/cloudposse-terraform-components/aws-managed-grafana-data-source-managed-prometheus/pull/60)