### PR TITLE
feat: wire full module v0.6.0 surface + fix cloudposse/utils v2 init conflict

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -22,7 +22,7 @@ module "security_group" {
 
 module "managed_grafana" {
   source  = "cloudposse/managed-grafana/aws"
-  version = "0.5.0"
+  version = "0.6.0"
 
   enabled = local.enabled
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -26,13 +26,20 @@ module "managed_grafana" {
 
   enabled = local.enabled
 
+  authentication_providers  = var.authentication_providers
+  permission_type           = var.permission_type
+  account_access_type       = var.account_access_type
+  organizational_units      = var.organizational_units
+  data_sources              = var.data_sources
+  grafana_version           = var.grafana_version
+  configuration             = var.configuration
   prometheus_policy_enabled = var.prometheus_policy_enabled
   additional_allowed_roles  = local.additional_allowed_roles
 
   vpc_configuration = var.private_network_access_enabled ? {
     subnet_ids         = module.vpc.outputs.private_subnet_ids
     security_group_ids = [module.security_group.id]
-  } : {}
+  } : null
 
   context = module.this.context
 }
@@ -44,6 +51,7 @@ resource "aws_grafana_role_association" "sso" {
 
   role      = each.value.role
   group_ids = each.value.group_ids
+  user_ids  = each.value.user_ids
 
   workspace_id = module.managed_grafana.workspace_id
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -3,6 +3,11 @@ output "workspace_id" {
   value       = module.managed_grafana.workspace_id
 }
 
+output "workspace_arn" {
+  description = "The ARN of the Amazon Managed Grafana workspace"
+  value       = module.managed_grafana.workspace_arn
+}
+
 output "workspace_endpoint" {
   description = "The returned URL of the Amazon Managed Grafana workspace"
   value       = module.managed_grafana.workspace_endpoint

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "prometheus" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   for_each = local.enabled ? {
     for target in var.prometheus_source_accounts : "${target.tenant}:${target.stage}:${target.environment}" => target
@@ -16,7 +16,7 @@ module "prometheus" {
 
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = "vpc"
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -6,9 +6,10 @@ variable "region" {
 variable "sso_role_associations" {
   type = list(object({
     role      = string
-    group_ids = list(string)
+    group_ids = optional(list(string), [])
+    user_ids  = optional(list(string), [])
   }))
-  description = "A list of role to group ID list associations for granting Amazon Grafana access"
+  description = "A list of role to group ID and user ID list associations for granting Amazon Grafana access. Only used when `var.authentication_providers` includes `AWS_SSO`."
   default     = []
 }
 
@@ -40,4 +41,50 @@ variable "private_network_access_enabled" {
   type        = bool
   description = "If set to `true`, enable the VPC Configuration to allow this workspace to access the private network using outputs from the vpc component"
   default     = false
+}
+
+variable "authentication_providers" {
+  type        = list(string)
+  description = "The authentication providers for the workspace. Valid values are `AWS_SSO`, `SAML`, or both."
+  default     = ["AWS_SSO"]
+}
+
+variable "permission_type" {
+  type        = string
+  description = "The permission type of the workspace. `SERVICE_MANAGED` generates the IAM role and policy attachments automatically; `CUSTOMER_MANAGED` does not."
+  default     = "SERVICE_MANAGED"
+}
+
+variable "account_access_type" {
+  type        = string
+  description = "The type of account access for the workspace. Valid values are `CURRENT_ACCOUNT` and `ORGANIZATION`. If `ORGANIZATION` is specified, `organizational_units` must also be present."
+  default     = "CURRENT_ACCOUNT"
+  validation {
+    condition     = contains(["CURRENT_ACCOUNT", "ORGANIZATION"], var.account_access_type)
+    error_message = "account_access_type must be either CURRENT_ACCOUNT or ORGANIZATION"
+  }
+}
+
+variable "organizational_units" {
+  type        = list(string)
+  description = "A list of organizational unit (OU) IDs to grant the workspace access to. Only used when `var.account_access_type` is `ORGANIZATION`."
+  default     = []
+}
+
+variable "data_sources" {
+  type        = list(string)
+  description = "The data sources for the workspace. Valid values include AMAZON_OPENSEARCH_SERVICE, ATHENA, CLOUDWATCH, PROMETHEUS, REDSHIFT, SITEWISE, TIMESTREAM, XRAY."
+  default     = []
+}
+
+variable "configuration" {
+  type        = string
+  description = "JSON string containing the workspace configuration. Use to enable Grafana unified alerting (`{\"unifiedAlerting\":{\"enabled\":true}}`) and/or plugin management (`{\"plugins\":{\"pluginAdminEnabled\":true}}`)."
+  default     = null
+}
+
+variable "grafana_version" {
+  type        = string
+  description = "The version of Grafana to support in the workspace (e.g. `9.4`, `10.4`, `12.4`). If not specified, AMG defaults to the latest supported version."
+  default     = null
 }


### PR DESCRIPTION
## what

- Bump `cloudposse/stack-config/yaml//modules/remote-state` **1.8.0 → 2.0.0** in `src/remote-state.tf` (both instances).
- Keep the module bump `cloudposse/managed-grafana/aws` **0.5.0 → 0.6.0** (supersedes #53).
- Expose the remaining module v0.6.0 inputs that the component did not surface: `authentication_providers`, `permission_type`, `account_access_type`, `organizational_units`, `data_sources`, `configuration`, `grafana_version`.
- Add `user_ids` to `sso_role_associations` (AWS_SSO user-level grants, alongside `group_ids`).
- Add the `workspace_arn` output.
- Pass `null` (module default) instead of `{}` on the off-branch of `vpc_configuration` — `{}` fails the module's `object({...})` type.

## why

**The blocker:** CI (`Lint (./src)`, `ci`) fails at `terraform init`:

```
Could not retrieve the list of available versions for provider cloudposse/utils:
no available releases match the given constraints >= 1.7.1, >= 2.0.0, < 2.0.0, < 3.0.0
```

`>= 2.0.0` ∧ `< 2.0.0` is empty. The `< 2.0.0` comes from `remote-state@1.8.0`, which hard-pins `cloudposse/utils >= 1.7.1, < 2.0.0`. The account-map `iam-roles` module the component depends on resolves at **utils v2** (`>= 2.0.0`), so the two are irreconcilable. `stack-config` `2.0.0` moves the remote-state pin to `>= 2.0.0, < 3.0.0`, resolving it. (This is independent of the module bump — neither 0.5.0 nor 0.6.0 declares `utils`; the renovate PR merely re-ran CI that surfaced the latent break.)

**The surface gap:** module v0.6.0 exposes auth/permission/data-source/config inputs the component never plumbed, so callers couldn't enable SAML, pick a permission model, choose data sources, set Grafana version, or turn on unified alerting. This wires them all through 1:1 with the module.

## test

- `terraform fmt` clean.
- Interface verified against the live module `v0.6.0` `variables.tf`/`outputs.tf`.
- Full `terraform init` / lint runs in CI (needs the account-map fixture).

## references

- module inputs: https://registry.terraform.io/modules/cloudposse/managed-grafana/aws/0.6.0
- utils v2 pin: `cloudposse/terraform-yaml-stack-config` `2.0.0` `modules/remote-state/versions.tf`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the workspace ARN as an available output.
  * Added configuration options for authentication providers, permissions, account access, organizational units, data sources, Grafana version, and custom settings.
  * SSO role associations can now assign both users and groups.
* **Improvements**
  * Expanded support for managed Grafana workspace configuration and private network access.
  * Updated infrastructure components for improved compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->